### PR TITLE
feat(auth): add sign-in server action

### DIFF
--- a/src/app/(auth)/sign-in/actions.ts
+++ b/src/app/(auth)/sign-in/actions.ts
@@ -1,0 +1,43 @@
+"use server";
+
+import { APIError } from "better-call";
+import { auth } from "@/src/lib/auth";
+import { signInSchema } from "@/src/server/validation/auth";
+import { type SignInActionResult } from "@/src/types/auth";
+
+const DEFAULT_REDIRECT = "/";
+const INVALID_CREDENTIALS_MESSAGE = "Invalid email or password.";
+
+export async function signInAction(
+  formData: FormData,
+): Promise<SignInActionResult> {
+  const raw = {
+    email: String(formData.get("email") || ""),
+    password: String(formData.get("password") || ""),
+  };
+
+  const parsed = signInSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      fieldErrors: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  try {
+    await auth.api.signInEmail({
+      body: {
+        email: parsed.data.email,
+        password: parsed.data.password,
+      },
+    });
+
+    return { ok: true, redirectTo: DEFAULT_REDIRECT };
+  } catch (error) {
+    if (error instanceof APIError) {
+      return { ok: false, formError: INVALID_CREDENTIALS_MESSAGE };
+    }
+
+    return { ok: false, formError: INVALID_CREDENTIALS_MESSAGE };
+  }
+}

--- a/src/server/validation/auth.ts
+++ b/src/server/validation/auth.ts
@@ -16,3 +16,10 @@ export const signupOwnerSchema = z.object({
 });
 
 export type SignUpInput = z.infer<typeof signupOwnerSchema>;
+
+export const signInSchema = z.object({
+  email: normalizedEmailSchema,
+  password: z.string().min(1, "Password is required"),
+});
+
+export type SignInInput = z.infer<typeof signInSchema>;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -5,3 +5,11 @@ export type SignupActionFieldErrors = Partial<
 export type SignupActionResult =
   | { ok: true; redirectTo: string }
   | { ok: false; fieldErrors?: SignupActionFieldErrors; formError?: string };
+
+export type SignInActionFieldErrors = Partial<
+  Record<"email" | "password", string[]>
+>;
+
+export type SignInActionResult =
+  | { ok: true; redirectTo: string }
+  | { ok: false; fieldErrors?: SignInActionFieldErrors; formError?: string };

--- a/tests/app/signin-action.test.ts
+++ b/tests/app/signin-action.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import prisma from "@/src/lib/prisma";
+import { auth } from "@/src/lib/auth";
+import { signInAction } from "@/src/app/(auth)/sign-in/actions";
+
+let dbAvailable: boolean | null = null;
+
+async function ensureDbAvailable() {
+  if (dbAvailable !== null) return dbAvailable;
+  try {
+    await prisma.$connect();
+    dbAvailable = true;
+  } catch {
+    dbAvailable = false;
+  }
+  return dbAvailable;
+}
+
+async function resetDb() {
+  await prisma.session.deleteMany();
+  await prisma.account.deleteMany();
+  await prisma.membership.deleteMany();
+  await prisma.agency.deleteMany();
+  await prisma.user.deleteMany();
+}
+
+function buildForm(overrides?: Partial<Record<string, string>>) {
+  const form = new FormData();
+  form.set("email", overrides?.email ?? "casey@example.com");
+  form.set("password", overrides?.password ?? "longpassword");
+  return form;
+}
+
+async function seedUser() {
+  await auth.api.signUpEmail({
+    body: {
+      name: "Casey",
+      email: "casey@example.com",
+      password: "longpassword",
+      agencyName: "Casey Agency",
+    },
+  });
+}
+
+describe("signInAction", () => {
+  beforeEach(async (t) => {
+    if (!(await ensureDbAvailable())) {
+      t.skip("Database not available");
+      return;
+    }
+    await resetDb();
+  });
+
+  it("returns fieldErrors for invalid input", async () => {
+    const result = await signInAction(
+      buildForm({ email: "not-an-email", password: "" }),
+    );
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.fieldErrors?.email?.length);
+      assert.ok(result.fieldErrors?.password?.length);
+    }
+  });
+
+  it("returns ok:false with a generic message for invalid credentials", async () => {
+    await seedUser();
+
+    const result = await signInAction(
+      buildForm({ password: "wrongpassword" }),
+    );
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.formError, "Invalid email or password.");
+    }
+  });
+
+  it("returns ok:true and redirectTo for valid credentials", async () => {
+    await seedUser();
+
+    const result = await signInAction(buildForm());
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.redirectTo, "/");
+    }
+  });
+});


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add sign-in server action with form validation and authentication

- Implement sign-in schema validation for email and password fields

- Define sign-in action result and field error types for type safety

- Add comprehensive test suite covering validation, errors, and success cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Form["FormData<br/>email, password"] -->|signInAction| Validate["Validate with<br/>signInSchema"]
  Validate -->|Invalid| FieldErrors["Return fieldErrors"]
  Validate -->|Valid| Auth["Call auth.api<br/>signInEmail"]
  Auth -->|Success| Redirect["Return ok:true<br/>redirectTo: /"]
  Auth -->|Error| FormError["Return ok:false<br/>formError"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Sign-in server action implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(auth)/sign-in/actions.ts

<ul><li>New server action <code>signInAction</code> that processes sign-in form data<br> <li> Validates email and password using <code>signInSchema</code><br> <li> Calls authentication API and handles errors with generic message<br> <li> Returns typed result with redirect or field/form errors</ul>


</details>


  </td>
  <td><a href="https://github.com/YeHtet214/Reviewly/pull/5/files#diff-270d76d1fbbd58cfe0240acaab6778a5adb5e5080750ebfa764fa2d0ae620bfb">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Add sign-in validation schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/validation/auth.ts

<ul><li>Add <code>signInSchema</code> validation object for email and password fields<br> <li> Define <code>SignInInput</code> type inferred from schema<br> <li> Reuse existing <code>normalizedEmailSchema</code> for email validation<br> <li> Password requires minimum 1 character (non-empty)</ul>


</details>


  </td>
  <td><a href="https://github.com/YeHtet214/Reviewly/pull/5/files#diff-c633112dc08396b477eae7942e3ae8aa40ddec38cafa51c27f346701ec33b179">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Add sign-in action result types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/auth.ts

<ul><li>Add <code>SignInActionFieldErrors</code> type for email and password validation <br>errors<br> <li> Add <code>SignInActionResult</code> union type for success and failure cases<br> <li> Mirrors structure of existing signup action result types</ul>


</details>


  </td>
  <td><a href="https://github.com/YeHtet214/Reviewly/pull/5/files#diff-2238b87570912aa9257bfe5f219b25d9f4f40385857687c6d24d4cbddf4ed29f">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signin-action.test.ts</strong><dd><code>Add sign-in action test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/app/signin-action.test.ts

<ul><li>Test suite with database setup, reset, and user seeding utilities<br> <li> Test invalid input validation returns field errors<br> <li> Test invalid credentials returns generic error message<br> <li> Test valid credentials returns success with redirect</ul>


</details>


  </td>
  <td><a href="https://github.com/YeHtet214/Reviewly/pull/5/files#diff-b11fc5d182a780ebb25d1348665e5b7a58e04d1d6ecba9d71a3fe60eeb7f1eb9">+90/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sign-in functionality allowing users to authenticate with email and password credentials
  * Implemented form validation with specific error messaging for invalid email format and empty passwords
  * Enhanced error handling that provides clear feedback for validation issues and incorrect credentials

* **Tests**
  * Added comprehensive test suite for sign-in operations covering validation scenarios, failed authentication attempts, and successful login flows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->