### PR TITLE
fix(invite): prevent agency creation for invite-based signup

### DIFF
--- a/src/app/(auth)/sign-up/actions.ts
+++ b/src/app/(auth)/sign-up/actions.ts
@@ -1,14 +1,67 @@
 "use server";
 
 import { APIError } from "better-call";
+import { z } from "zod";
+import { InvitationType, Role } from "@/prisma/generated/client";
 import { auth } from "@/src/lib/auth";
+import prisma from "@/src/lib/prisma";
+import { getValidInvitation } from "@/src/server/invitations/get-invite";
 import { signupOwnerSchema } from "@/src/server/validation/auth";
 import { type SignupActionResult } from "@/src/types/auth";
 
 const DEFAULT_REDIRECT = "/";
-const INVITE_REDIRECT = "/invite/complete";
+const DEFAULT_SIGNUP_ERROR_MESSAGE = "Unable to create account.";
+const DEFAULT_INVITE_ERROR_MESSAGE = "Invite link is invalid or expired.";
 
-export async function signupOwnerAction(
+const normalizedEmailSchema = z.preprocess(
+	(value) => {
+		if (typeof value !== "string") return value;
+		return value.trim().toLowerCase();
+	},
+	z.string().email("Email is invalid"),
+);
+
+const inviteSignupSchema = z.object({
+	name: z.string().min(1, "Name is required"),
+	email: normalizedEmailSchema,
+	password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+const normalizeEmail = (value: string) => value.trim().toLowerCase();
+
+const EMAIL_ALREADY_EXISTS_CODES = new Set([
+	"ACCOUNT_EXISTS",
+	"USER_ALREADY_EXISTS",
+	"USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL",
+]);
+
+function mapSignupError(error: unknown): SignupActionResult {
+	if (error instanceof APIError) {
+		const errorBody = error.body;
+		const errorCode =
+			typeof errorBody?.code === "string" ? errorBody.code : undefined;
+		const errorMessage = String(error.message || "");
+		if (
+			(errorCode && EMAIL_ALREADY_EXISTS_CODES.has(errorCode)) ||
+			errorMessage.toLowerCase().includes("already exists") ||
+			errorMessage.toLowerCase().includes("already in use")
+		) {
+			return {
+				ok: false,
+				fieldErrors: { email: ["Email already in use."] },
+			};
+		}
+		return {
+			ok: false,
+			formError:
+				error.body?.message || error.message || DEFAULT_SIGNUP_ERROR_MESSAGE,
+		};
+	}
+
+	return { ok: false, formError: DEFAULT_SIGNUP_ERROR_MESSAGE };
+}
+
+export async function signupAction(
 	formData: FormData,
 ): Promise<SignupActionResult> {
 	const raw = {
@@ -19,7 +72,144 @@ export async function signupOwnerAction(
 	};
 	const inviteToken = String(formData.get("inviteToken") || "").trim();
 
-	const parsed = signupOwnerSchema.safeParse(raw);
+	if (inviteToken) {
+		return signupInvite(raw.name, raw.email, raw.password, inviteToken);
+	}
+
+	return signupOwner(raw.name, raw.email, raw.password, raw.agencyName);
+}
+
+async function signupInvite(
+	name: string,
+	email: string,
+	password: string,
+	inviteToken: string,
+): Promise<SignupActionResult> {
+	const inviteParsed = inviteSignupSchema.safeParse({
+		name,
+		email,
+		password,
+	});
+	if (!inviteParsed.success) {
+		return {
+			ok: false,
+			fieldErrors: inviteParsed.error.flatten().fieldErrors,
+		};
+	}
+
+	const inviteResult = await getValidInvitation(inviteToken);
+	if (!inviteResult.ok) {
+		return { ok: false, formError: DEFAULT_INVITE_ERROR_MESSAGE };
+	}
+
+	const invitation = inviteResult.invitation;
+	if (invitation.type !== InvitationType.MEMBER) {
+		return { ok: false, formError: DEFAULT_INVITE_ERROR_MESSAGE };
+	}
+
+	const agencyId = invitation.agencyId;
+	if (!agencyId) {
+		return { ok: false, formError: DEFAULT_INVITE_ERROR_MESSAGE };
+	}
+
+	const normalizedSignupEmail = normalizeEmail(inviteParsed.data.email);
+	const normalizedInviteEmail = normalizeEmail(invitation.email);
+	if (normalizedSignupEmail !== normalizedInviteEmail) {
+		return {
+			ok: false,
+			fieldErrors: { email: ["Email does not match invitation."] },
+		};
+	}
+
+	let userId: string | null = null;
+
+	try {
+		type SignUpEmailBody =
+			NonNullable<Parameters<typeof auth.api.signUpEmail>[0]>["body"] & {
+			inviteToken: string;
+		};
+
+		const body: SignUpEmailBody = {
+			name: inviteParsed.data.name,
+			email: inviteParsed.data.email,
+			password: inviteParsed.data.password,
+			inviteToken,
+		};
+
+		const response = await auth.api.signUpEmail({
+			body,
+		});
+		userId = response?.user?.id ?? null;
+	} catch (error: unknown) {
+		return mapSignupError(error);
+	}
+
+	if (!userId) {
+		return { ok: false, formError: DEFAULT_SIGNUP_ERROR_MESSAGE };
+	}
+
+	const consumedAt = new Date();
+	const role = invitation.role ?? Role.MEMBER;
+
+	try {
+		await prisma.$transaction(async (tx) => {
+			const updated = await tx.invitation.updateMany({
+				where: {
+					id: invitation.id,
+					consumedAt: null,
+					expiresAt: { gte: consumedAt },
+					type: InvitationType.MEMBER,
+					agencyId: { not: null },
+				},
+				data: { consumedAt },
+			});
+
+			if (updated.count === 0) {
+				throw new Error("Invite already consumed.");
+			}
+
+			const existingMembership = await tx.membership.findFirst({
+				where: {
+					userId,
+					agencyId,
+				},
+				select: { id: true },
+			});
+
+			if (!existingMembership) {
+				await tx.membership.create({
+					data: {
+						userId,
+						agencyId,
+						role,
+					},
+				});
+			}
+		});
+	} catch {
+		try {
+			await prisma.user.delete({ where: { id: userId } });
+		} catch (cleanupError) {
+			console.error("signupOwnerAction: invite cleanup failed", cleanupError);
+		}
+		return { ok: false, formError: DEFAULT_INVITE_ERROR_MESSAGE };
+	}
+
+	return { ok: true, redirectTo: DEFAULT_REDIRECT };
+}
+
+async function signupOwner(
+	name: string,
+	email: string,
+	password: string,
+	agencyName: string,
+): Promise<SignupActionResult> {
+	const parsed = signupOwnerSchema.safeParse({
+		name,
+		email,
+		password,
+		agencyName,
+	});
 	if (!parsed.success) {
 		return {
 			ok: false,
@@ -41,35 +231,8 @@ export async function signupOwnerAction(
 
 		await auth.api.signUpEmail({ body });
 
-		const redirectTo = inviteToken
-			? `${INVITE_REDIRECT}?token=${encodeURIComponent(inviteToken)}`
-			: DEFAULT_REDIRECT;
-		return { ok: true, redirectTo };
+		return { ok: true, redirectTo: DEFAULT_REDIRECT };
 	} catch (error: unknown) {
-		if (error instanceof APIError) {
-			const errorBody = error.body;
-			const errorCode =
-				typeof errorBody?.code === "string" ? errorBody.code : undefined;
-			const errorMessage = String(error.message || "");
-			if (
-				errorCode === "ACCOUNT_EXISTS" ||
-				errorCode === "USER_ALREADY_EXISTS" ||
-				errorCode === "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL" ||
-				errorMessage.toLowerCase().includes("already exists") ||
-				errorMessage.toLowerCase().includes("already in use")
-			) {
-				return {
-					ok: false,
-					fieldErrors: { email: ["Email already in use."] },
-				};
-			}
-			return {
-				ok: false,
-				formError:
-					error.body?.message || error.message || "Unable to create account.",
-			};
-		}
-
-		return { ok: false, formError: "Unable to create account." };
+		return mapSignupError(error);
 	}
 }

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useState, useTransition } from "react";
-import { signupOwnerAction } from "./actions";
+import { signupAction } from "./actions";
 
 type FieldErrors = Partial<
   Record<"name" | "email" | "password" | "agencyName", string[]>
@@ -23,7 +23,7 @@ export default function SignupPage() {
       setFormError(null);
       setFieldErrors({});
 
-      const result = await signupOwnerAction(formData);
+      const result = await signupAction(formData);
 
       if (result.ok) {
         router.push(result.redirectTo);
@@ -99,24 +99,9 @@ export default function SignupPage() {
                 ) : null}
               </div>
 
-              <div className="stack-2">
-                <label htmlFor="agencyName" className="label">
-                  Agency name
-                </label>
-                <input
-                  id="agencyName"
-                  name="agencyName"
-                  type="text"
-                  placeholder="Your agency"
-                  autoComplete="organization"
-                  className={`input${
-                    fieldErrors.agencyName?.[0] ? " input-invalid" : ""
-                  }`}
-                />
-                {fieldErrors.agencyName?.[0] ? (
-                  <p className="error-text">{fieldErrors.agencyName[0]}</p>
-                ) : null}
-              </div>
+              <Suspense fallback={<AgencyNameFieldFallback fieldErrors={fieldErrors} />}>
+                <AgencyNameField fieldErrors={fieldErrors} />
+              </Suspense>
             </div>
 
             <button type="submit" disabled={isPending} className="btn-primary w-full">
@@ -189,6 +174,55 @@ function InviteFieldsFallback({ fieldErrors }: { fieldErrors: FieldErrors }) {
         ) : null}
       </div>
     </>
+  );
+}
+
+function AgencyNameField({ fieldErrors }: { fieldErrors: FieldErrors }) {
+  const searchParams = useSearchParams();
+  const inviteToken = searchParams.get("inviteToken") ?? "";
+
+  if (inviteToken) {
+    return null;
+  }
+
+  return (
+    <div className="stack-2">
+      <label htmlFor="agencyName" className="label">
+        Agency name
+      </label>
+      <input
+        id="agencyName"
+        name="agencyName"
+        type="text"
+        placeholder="Your agency"
+        autoComplete="organization"
+        className={`input${fieldErrors.agencyName?.[0] ? " input-invalid" : ""}`}
+      />
+      {fieldErrors.agencyName?.[0] ? (
+        <p className="error-text">{fieldErrors.agencyName[0]}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function AgencyNameFieldFallback({ fieldErrors }: { fieldErrors: FieldErrors }) {
+  return (
+    <div className="stack-2">
+      <label htmlFor="agencyName" className="label">
+        Agency name
+      </label>
+      <input
+        id="agencyName"
+        name="agencyName"
+        type="text"
+        placeholder="Your agency"
+        autoComplete="organization"
+        className={`input${fieldErrors.agencyName?.[0] ? " input-invalid" : ""}`}
+      />
+      {fieldErrors.agencyName?.[0] ? (
+        <p className="error-text">{fieldErrors.agencyName[0]}</p>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,8 +4,9 @@ import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError } from "better-call";
-import { Role } from "@/prisma/generated/client";
+import { InvitationType, Role } from "@/prisma/generated/client";
 import prisma from "@/src/lib/prisma";
+import { getValidInvitation } from "@/src/server/invitations/get-invite";
 import { randomUUID } from "crypto";
 
 export const authConfig = {
@@ -20,6 +21,31 @@ export const authConfig = {
 					context: GenericEndpointContext | null,
 				) => {
 					if (!context?.path?.endsWith("/sign-up/email")) return;
+
+					const normalizeEmail = (value: unknown) => {
+						if (typeof value !== "string") return "";
+						return value.trim().toLowerCase();
+					};
+
+					const inviteToken =
+						typeof context?.body?.inviteToken === "string"
+							? context.body.inviteToken.trim()
+							: "";
+
+					if (inviteToken) {
+						const inviteResult = await getValidInvitation(inviteToken);
+						if (
+							inviteResult.ok &&
+							inviteResult.invitation.type === InvitationType.MEMBER &&
+							inviteResult.invitation.agencyId
+						) {
+							const inviteEmail = normalizeEmail(inviteResult.invitation.email);
+							const signupEmail = normalizeEmail(context?.body?.email);
+							if (inviteEmail && inviteEmail === signupEmail) {
+								return;
+							}
+						}
+					}
 
 					const agencyName =
 						typeof context?.body?.agencyName === "string"


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Separate invite-based signup from owner signup flow

- Prevent agency creation when signing up via invite link

- Validate invite token and match email before account creation

- Conditionally hide agency name field for invite-based signups


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sign-up Form"] --> B{"Invite Token Present?"}
  B -->|Yes| C["signupInvite"]
  B -->|No| D["signupOwner"]
  C --> E["Validate Invite"]
  E --> F["Match Email"]
  F --> G["Create User & Membership"]
  D --> H["Create User & Agency"]
  G --> I["Redirect to Home"]
  H --> I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Split signup into invite and owner flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(auth)/sign-up/actions.ts

<ul><li>Refactored signup logic into two separate functions: <code>signupInvite</code> and <br><code>signupOwner</code><br> <li> Added invite validation with email matching and invitation consumption <br>logic<br> <li> Extracted error mapping into <code>mapSignupError</code> utility function<br> <li> Added schemas for invite signup validation with normalized email <br>handling<br> <li> Implemented database transaction to atomically update invitation and <br>create membership</ul>


</details>


  </td>
  <td><a href="https://github.com/YeHtet214/Reviewly/pull/20/files#diff-116d5a7bae11ba2bc52e664d8496de75c05abd7141cbae7a03353a5028c18cbb">+195/-32</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Conditionally hide agency field for invites</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(auth)/sign-up/page.tsx

<ul><li>Renamed <code>signupOwnerAction</code> to <code>signupAction</code> for unified entry point<br> <li> Wrapped agency name field in <code>Suspense</code> with fallback component<br> <li> Created <code>AgencyNameField</code> component that conditionally hides field for <br>invite-based signups<br> <li> Added <code>AgencyNameFieldFallback</code> component for loading state</ul>


</details>


  </td>
  <td><a href="https://github.com/YeHtet214/Reviewly/pull/20/files#diff-ddaf4958338e04d7cb5bcb565fe4bb168ae3274fd7be1209e9be105ad66d8384">+54/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Prevent agency creation for invite signups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/auth.ts

<ul><li>Added invite token validation in user creation hook<br> <li> Skip agency creation when valid invite token is present with matching <br>email<br> <li> Added email normalization utility for consistent comparison<br> <li> Import <code>InvitationType</code> and <code>getValidInvitation</code> for invite handling</ul>


</details>


  </td>
  <td><a href="https://github.com/YeHtet214/Reviewly/pull/20/files#diff-486994d46df34c53636a706a1ca6a05bd8261ccde47463ea2c739af56f090b78">+27/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sign-up now supports invitation-based registration alongside standard owner signup.
  * Agency name field is intelligently hidden when signing up through an invitation link.

* **Bug Fixes**
  * Enhanced email validation with normalization for improved consistency and accuracy.
  * Improved error handling with clearer, user-focused messaging for common signup issues.
  * Added password length requirements validation during the sign-up process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->